### PR TITLE
Fix "\r\n" not being escaped

### DIFF
--- a/src/BugsnagPlugin.php
+++ b/src/BugsnagPlugin.php
@@ -52,7 +52,7 @@ class BugsnagPlugin extends Plugin
         Craft::$app->set('bugsnag', [
             'class' => 'pinfirestudios\yii2bugsnag\BugsnagComponent',
             'bugsnag_api_key' => $settings->apiKey, 
-            'notifyReleaseStages' => explode("\n", str_replace("\r", "", $settings->notifyReleaseStages)),
+            'notifyReleaseStages' => preg_split('/\r\n|\r|\n/', $settings->notifyReleaseStages),
 			'releaseStage' => $settings->releaseStage ?? CRAFT_ENVIRONMENT
         ]);
 

--- a/src/BugsnagPlugin.php
+++ b/src/BugsnagPlugin.php
@@ -52,7 +52,7 @@ class BugsnagPlugin extends Plugin
         Craft::$app->set('bugsnag', [
             'class' => 'pinfirestudios\yii2bugsnag\BugsnagComponent',
             'bugsnag_api_key' => $settings->apiKey, 
-            'notifyReleaseStages' => explode("\n", $settings->notifyReleaseStages),
+            'notifyReleaseStages' => explode("\n", str_replace("\r", "", $settings->notifyReleaseStages)),
 			'releaseStage' => $settings->releaseStage ?? CRAFT_ENVIRONMENT
         ]);
 


### PR DESCRIPTION
On certain systems (I'm on a Mac), the release stages aren't being escaped properly. I imagine because you're splitting based on line endings, which are `\r\n`. As such, it'll produce things like:

```
Bugsnag.notifyReleaseStages = ["staging\r","production"];
```

Which won't send errors at all.